### PR TITLE
Fix Vite dynamic import warnings and update Browserslist

### DIFF
--- a/src/components/Book.jsx
+++ b/src/components/Book.jsx
@@ -1,14 +1,19 @@
 import React, { useEffect, useState } from "react";
 
+const imageModules = import.meta.glob("../BookImg/*", { eager: true });
+
 const Book = ({ book }) => {
   const [imageSrc, setImageSrc] = useState(null);
 
   useEffect(() => {
-    import(`../BookImg/${book.Img}`)
-      .then((module) => {
-        setImageSrc(module.default);
-      })
-      .catch((error) => console.error("Error loading image:", error));
+    const imagePath = `../BookImg/${book.Img}`;
+    const module = imageModules[imagePath];
+    
+    if (module) {
+      setImageSrc(module.default);
+    } else {
+      console.error(`Image not found: ${imagePath}`);
+    }
   }, [book.Img]);
 
   if (!imageSrc) {


### PR DESCRIPTION
## Overview
Fixes Vite build warnings related to dynamic imports and outdated browser compatibility database.

## Changes
- **Book.jsx**: Replace dynamic `import()` with Vite's `import.meta.glob()` for statically analyzable image imports
  - Resolves Vite's `dynamic-import-vars` plugin warning
  - Images are now pre-loaded in a synchronous glob pattern
  
- **Browserslist**: Run `npx update-browserslist-db@latest` to update caniuse-lite data

## Why
- Vite cannot analyze dynamic imports with variable file extensions in the static part of the path
- `import.meta.glob()` is Vite's recommended approach for this use case
- Keeping caniuse-lite updated ensures accurate browser compatibility data

## Testing
The changes maintain the same functionality while eliminating warnings during the build process.